### PR TITLE
fixed support for using semantic

### DIFF
--- a/assimp.odin
+++ b/assimp.odin
@@ -1,4 +1,6 @@
+#+feature using-stmt
 package assimp
+
 
 /*
 Assimp


### PR DESCRIPTION
added #+feature using-stmt at the top of the assimp file so it works on newer versions of odin where "using" semantic changed