### PR TITLE
fix: corrected the enum definition for aiReturn

### DIFF
--- a/import/assimp.odin
+++ b/import/assimp.odin
@@ -229,8 +229,8 @@ aiString :: struct {
 
 aiReturn :: enum u32 {
 	SUCCESS     = 0x0,
-	FAILURE     = 0x1,
-	OUTOFMEMORY = 0x3,
+	FAILURE     = ~u32(0), // -0x1
+	OUTOFMEMORY = ~u32(2), // -0x3
 }
 
 aiOrigin :: enum u32 {


### PR DESCRIPTION
The `FAILURE` and `OUTOFMEMORY` are incorrectly defined:

```
aiReturn :: enum u32 {
	SUCCESS     = 0x0,
	FAILURE     = 0x1,
	OUTOFMEMORY = 0x3
}
```

It seems the negative value casts are not considered from the reference

they should be instead:

```
aiReturn :: enum u32 {
	SUCCESS     = 0x0,
	FAILURE     = ~u32(0), // -0x1
	OUTOFMEMORY = ~u32(2), // -0x3
}
```

Reference from the github repo of assimp: https://github.com/assimp/assimp/blob/abc3784e3927c5e9866e123707883e3b8e1e2d76/port/dAssimp/assimp/types.d#L144
